### PR TITLE
Correctly handle HTTP 201 response from current Seafile server

### DIFF
--- a/seafile-share-link
+++ b/seafile-share-link
@@ -102,7 +102,7 @@ curl -i --silent -X PUT -d "type=$FILE_OR_DIR&p=$DIR_INSIDE_REPO/$FILE_NAME" \
 	tr -d '\r' |
 	(
 	    read line
-	    if [ "$line" != 'HTTP/1.1 201 CREATED' ]
+	    if [ "$line" != 'HTTP/1.1 201 CREATED' && "$line" != 'HTTP/1.1 201 Created' ]
 	    then
 		echo "Unexpected HTTP-respononce: '$line'" >&2
 		exit 6

--- a/seafile-share-link
+++ b/seafile-share-link
@@ -102,7 +102,7 @@ curl -i --silent -X PUT -d "type=$FILE_OR_DIR&p=$DIR_INSIDE_REPO/$FILE_NAME" \
 	tr -d '\r' |
 	(
 	    read line
-	    if [ "$line" != 'HTTP/1.1 201 CREATED' && "$line" != 'HTTP/1.1 201 Created' ]
+	    if [ "$line" != 'HTTP/1.1 201 CREATED' ] && [ "$line" != 'HTTP/1.1 201 Created' ]
 	    then
 		echo "Unexpected HTTP-respononce: '$line'" >&2
 		exit 6


### PR DESCRIPTION
My current 8.x Seafile server (and probably also previous server versions) responds with 'HTTP/1.1 201 Created' instead of 'HTTP/1.1 201 CREATED' on successful creation of a share link. The shell script should accept both versions.